### PR TITLE
Adding procedure to login once thru the UI and keeping cookies to reuse login-state

### DIFF
--- a/cypress/integration/changeAccountSettingsSmoketest.spec.js
+++ b/cypress/integration/changeAccountSettingsSmoketest.spec.js
@@ -11,7 +11,7 @@ let editShippingAddressPage;
 // });
 
 beforeEach(() => {
-  new LoginPage().loginUser();
+//   new LoginPage().loginUser();
   const myAccountPage = new MyAccountPage();
   myAccountPage.getAccountPopOverName()
     .should('be.visible')

--- a/cypress/integration/changeAccountSettingsSmoketest.spec.js
+++ b/cypress/integration/changeAccountSettingsSmoketest.spec.js
@@ -6,18 +6,15 @@ const generateRandomData = new GenerateRandomData();
 let accountSettingsPage;
 let editShippingAddressPage;
 
-// before(() => {
-//   new LoginPage().loginUser();
-// });
-
 beforeEach(() => {
-//   new LoginPage().loginUser();
   const myAccountPage = new MyAccountPage();
   myAccountPage.getAccountPopOverName()
     .should('be.visible')
     .should('not.have.text', '');
   accountSettingsPage = myAccountPage.goToAccountSettings();
-  accountSettingsPage.getDisplayedAddress().invoke('text').as('originalAddress');
+  accountSettingsPage.getDisplayedAddress()
+    .should('be.visible')
+    .invoke('text').as('originalAddress');
   cy.get('@originalAddress').then((text) => {
     cy.log('the originalAddress is ' + text);
   })
@@ -28,6 +25,9 @@ describe('Change Account Settings Smoketests', () => {
 
     it('Negative Test: Change All Address Values (valid US Address) on Account Settings and Cancel Changes', () => {
         const randomStringForTestData = generateRandomData.generateRandomString();
+        editShippingAddressPage.getFirstNameInput()
+            .should('be.visible')
+            .should('be.enabled');
         editShippingAddressPage.changeFirstName(randomStringForTestData);
         editShippingAddressPage.changeLastName(randomStringForTestData);
         editShippingAddressPage.changeCompany(randomStringForTestData);
@@ -53,6 +53,9 @@ describe('Change Account Settings Smoketests', () => {
 
     it('Change All Address Values (valid US Address) on Account Settings and Save Changes', () => {
         const randomStringForTestData =  generateRandomData.generateRandomString();
+        editShippingAddressPage.getFirstNameInput()
+            .should('be.visible')
+            .should('be.enabled');
         editShippingAddressPage.changeFirstName(randomStringForTestData);
         editShippingAddressPage.changeLastName(randomStringForTestData);
         editShippingAddressPage.changeCompany(randomStringForTestData);
@@ -80,6 +83,9 @@ describe('Change Account Settings Smoketests', () => {
 
     it('Change All Address Values (valid Canada Address) on Account Settings and Save Changes', () => {
         const randomStringForTestData =  generateRandomData.generateRandomString();
+        editShippingAddressPage.getFirstNameInput()
+            .should('be.visible')
+            .should('be.enabled');
         editShippingAddressPage.changeFirstName(randomStringForTestData);
         editShippingAddressPage.changeLastName(randomStringForTestData);
         editShippingAddressPage.changeCompany(randomStringForTestData);
@@ -107,7 +113,9 @@ describe('Change Account Settings Smoketests', () => {
 
     it('Negative Test: Change Zip Code to empty value on Account Settings and Verify Error on Required field', () => {
         editShippingAddressPage.getZipCodeInput()
-        .clear();
+            .should('be.visible')
+            .should('be.enabled')
+            .clear();
         editShippingAddressPage.saveChanges();
         editShippingAddressPage.waitForRequiredFieldErrorMessage();
         editShippingAddressPage.getRequiredFieldErrorMessage()
@@ -127,7 +135,9 @@ describe('Change Account Settings Smoketests', () => {
 
     it('Negative Test: Change First Name to empty value on Account Settings and Verify Error on Required field', () => {
         editShippingAddressPage.getFirstNameInput()
-        .clear();
+            .should('be.visible')
+            .should('be.enabled')
+            .clear();
         editShippingAddressPage.saveChanges();
         editShippingAddressPage.waitForRequiredFieldErrorMessage();
         editShippingAddressPage.getRequiredFieldErrorMessage()
@@ -147,7 +157,9 @@ describe('Change Account Settings Smoketests', () => {
 
     it('Negative Test: Change Last Name to empty value on Account Settings and Verify Error on Required field', () => {
         editShippingAddressPage.getLastNameInput()
-        .clear();
+            .should('be.visible')
+            .should('be.enabled')
+            .clear();
         editShippingAddressPage.saveChanges();
         editShippingAddressPage.waitForRequiredFieldErrorMessage();
         editShippingAddressPage.getRequiredFieldErrorMessage()
@@ -167,7 +179,9 @@ describe('Change Account Settings Smoketests', () => {
 
     it('Negative Test: Change Street Address to empty value on Account Settings and Verify Error on Required field', () => {
         editShippingAddressPage.getStreetAddressInput()
-        .clear();
+            .should('be.visible')
+            .should('be.enabled')
+            .clear();
         editShippingAddressPage.saveChanges();
         editShippingAddressPage.waitForRequiredFieldErrorMessage();
         editShippingAddressPage.getRequiredFieldErrorMessage()
@@ -187,7 +201,9 @@ describe('Change Account Settings Smoketests', () => {
 
     it('Negative Test: Change City to empty value on Account Settings and Verify Error on Required field', () => {
         editShippingAddressPage.getCityInput()
-        .clear();
+            .should('be.visible')
+            .should('be.enabled')
+            .clear();
         editShippingAddressPage.saveChanges();
         editShippingAddressPage.waitForRequiredFieldErrorMessage();
         editShippingAddressPage.getRequiredFieldErrorMessage()

--- a/cypress/integration/changeChildDetailsSmoketest.spec.js
+++ b/cypress/integration/changeChildDetailsSmoketest.spec.js
@@ -11,7 +11,7 @@ let editChildDetailsPage;
 // });
 
 beforeEach(() => {
-    new LoginPage().loginUser();
+    // new LoginPage().loginUser();
     const myAccountPage = new MyAccountPage();
     myAccountPage.getAccountPopOverName()
         .should('be.visible')

--- a/cypress/integration/changeChildDetailsSmoketest.spec.js
+++ b/cypress/integration/changeChildDetailsSmoketest.spec.js
@@ -6,18 +6,15 @@ const generateRandomData = new GenerateRandomData();
 let profileInfoPage;
 let editChildDetailsPage;
 
-// before(() => {
-//   new LoginPage().loginUser();
-// });
-
 beforeEach(() => {
-    // new LoginPage().loginUser();
     const myAccountPage = new MyAccountPage();
     myAccountPage.getAccountPopOverName()
         .should('be.visible')
         .should('not.have.text', '');
     profileInfoPage = myAccountPage.goToProfileInfo();
-    profileInfoPage.getChildDetailsName().invoke('text').as('currentChildDetailsName');
+    profileInfoPage.getChildDetailsName()
+        .should('be.visible')
+        .invoke('text').as('currentChildDetailsName');
     cy.get('@currentChildDetailsName').then((text) => {
         cy.log('the currentChildDetailsName is ' + text);
     })

--- a/cypress/integration/changeContactDetailsSmokeTest.spec.js
+++ b/cypress/integration/changeContactDetailsSmokeTest.spec.js
@@ -11,7 +11,7 @@ let editContactDetailsPage;
 // });
 
 beforeEach(() => {
-  new LoginPage().loginUser();
+  // new LoginPage().loginUser();
   const myAccountPage = new MyAccountPage();
   myAccountPage.getAccountPopOverName()
     .should('be.visible')

--- a/cypress/integration/changeContactDetailsSmokeTest.spec.js
+++ b/cypress/integration/changeContactDetailsSmokeTest.spec.js
@@ -6,12 +6,7 @@ const generateRandomData = new GenerateRandomData();
 let profileInfoPage;
 let editContactDetailsPage;
 
-// before(() => {
-//   new LoginPage().loginUser();
-// });
-
 beforeEach(() => {
-  // new LoginPage().loginUser();
   const myAccountPage = new MyAccountPage();
   myAccountPage.getAccountPopOverName()
     .should('be.visible')
@@ -19,7 +14,9 @@ beforeEach(() => {
   profileInfoPage = myAccountPage.goToProfileInfo();
   // Example of storing text value as a variable
   // https://stackoverflow.com/questions/70743343/get-text-from-an-element-and-store-in-a-variable-in-cypress
-  profileInfoPage.getContactDetailsName().invoke('text').as('currentContactDetailsName');
+  profileInfoPage.getContactDetailsName()
+    .should('be.visible')  
+    .invoke('text').as('currentContactDetailsName');
   cy.get('@currentContactDetailsName').then((text) => {
     cy.log('the currentContactDetailsName is ' + text);
   })

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -14,7 +14,9 @@
 // ***********************************************************
 
 // Import commands.js using ES2015 syntax:
-import './commands'
+import './commands';
+
+import { LoginPage } from './pageObjects/LoginPage';
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
@@ -24,3 +26,28 @@ Cypress.on('uncaught:exception', (err, runnable) => {
   // failing the test
     return false
     })
+
+// To login thru the UI only once before running all the tests
+before(() => {
+  new LoginPage().loginUser();
+});
+
+// Trying out workaround for saving login state with cookies for each test run
+// https://dzone.com/articles/cypress-preserve-cookies-and-keep-login-session-active-in-tests
+afterEach(() => {
+  //Code to Handle the Sesssions in cypress.
+  //Keep the Session alive when you jump to another test
+  let str = [];
+  cy.getCookies().then((cook) => {
+    cy.log(cook);
+    for (let l = 0; l < cook.length; l++) {
+      if (cook.length > 0 && l == 0) {
+        str[l] = cook[l].name;
+        Cypress.Cookies.preserveOnce(str[l]);
+      } else if (cook.length > 1 && l > 1) {
+        str[l] = cook[l].name;
+        Cypress.Cookies.preserveOnce(str[l]);
+      }
+    }
+  })
+})

--- a/cypress/support/pageObjects/EditShippingAddressPage.js
+++ b/cypress/support/pageObjects/EditShippingAddressPage.js
@@ -25,7 +25,7 @@ export class EditShippingAddressPage {
     }
 
     getAptInput() {
-        return cy.get("input[placeholder='Apt, Suite, or Floor']");
+        return cy.get("input[name='line2']");
     }
     
     getCityInput() {


### PR DESCRIPTION
- Adding login procedure using the LoginPage object on the index.js file from the support folder. This will allow to only log in thru the UI before all the tests, then keeping the cookies alive thru all the tests so there is no need to relogin
- Adding minor assertions to the tests on the Account Settings Page
- Fixing the locator for the Apt input field on the Edit Shipping Address Page